### PR TITLE
Cambios estilos textos home, links footer fef, estilos replicados sid…

### DIFF
--- a/capitulo-1.html
+++ b/capitulo-1.html
@@ -305,6 +305,10 @@
     <div class="menu-bar">
         <div class="menu-bar__bt"></div>
     </div>
+
+
+
+    
     <!-- Masthead-->
     <header class="masthead-2">
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -4611,6 +4611,7 @@ fieldset:disabled .btn {
   padding: 0.5rem 1rem;
   color: #F27961;
   text-decoration: none;
+  letter-spacing: 0.08rem;
   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
 }
 
@@ -13122,7 +13123,7 @@ line-height: 10px !important;
 
 
 /* textos prompt  */
-.text-white-p, .texto-audio, .intro-home, .cuñas-home {
+.text-white-p, .texto-audio, .intro-home, .cuñas-home, .wsp-text {
   letter-spacing: 0.1rem;
   line-height: 1.4rem;
 }
@@ -13134,6 +13135,11 @@ line-height: 10px !important;
 }
 
 .intro-home {
+  font-weight: 300;
+  font-size: 1.2rem;
+}
+
+.cuñas-home {
   font-weight: 200;
   font-size: 1.2rem;
 }
@@ -13145,9 +13151,19 @@ font-size: 1.1rem;
 
 .nombre-personaje {
   font-size: 1rem;
-  font-weight: 100;
+  font-weight: 200;
   font-style: italic;
 }
+
+.wsp-text {
+  font-size: 1.2rem;
+  }
+
+.icon-text {
+  font-size: 0.9rem !important;
+  letter-spacing: 0.1rem;
+  font-weight: 200 !important;
+} 
 
 .regular-bold {
   font-weight: normal;
@@ -13211,12 +13227,6 @@ font-size: 1.1rem;
  .btn .submenu-text:active {
   color: coral !important;
 }
-
-
-
- .wsp-text {
- font-size: 20px;
- }
 
 .min_map_title {
   font-weight: 300 !important;

--- a/index.html
+++ b/index.html
@@ -206,15 +206,15 @@
 
                 <div class="row mt-5 justify-content-evenly align-content-center">
 
-                    <div class="zonas col-4" id="zonas">
+                    <div class="zonas col-4">
                         <div class="caja c1">
                             <h5 class="text-white regular-bold mt-5 mb-3 menu-cap">ZONA 1: COQUIMBO </h5>
-                            <a class="text-white submenu-text" onclick="myFunction()">·SECTOR: C. CHUNGUNGO</a>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: C. CHUNGUNGO</a>
                         </div>
                         <div class="caja c4">
                             <h5 class="text-white mt-5 regular-bold mb-3 menu-cap">ZONA 2: VALPARAÍSO </h5>
-                            <a class="text-white submenu-text" onclick="myFunction()">·SECTOR: ZAPALLAR</a>
-                            <a class="text-white submenu-text" onclick="myFunction()">·SECTOR: ALGARROBO</a>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: ZAPALLAR</a>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: ALGARROBO</a>
                         </div>
                         <div class="caja c6">
                             <h5 class="text-white mt-5 regular-bold mb-3 menu-cap">ZONA 3: BÍO BÍO </h5>
@@ -223,7 +223,6 @@
                         <div class="caja c8 ">
                             <h5 class="text-white mt-5 mb-3 menu-cap">ZONA 4: LOS LAGOS </h5>
                             <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: HUALAIHUÉ</a>
-                          
                         </div>
                     </div>
                    
@@ -405,7 +404,7 @@
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">
                 <div class="col-lg-8 text-center mb-5">
-                    <p class="text-white-p light-text intro-home ">“¿Puedes escuchar el mar cuando acercas a tu oído una caracola marina? Te tenemos una invitación... a conocer el sonido de la costa, las voces de sus habitantes, sus preocupaciones y sus formas de cuidar el territorio y el mar. Dale play a nuestro podcast y sumérgete en estos testimonios sonoros sobre la vida y el futuro sostenible de las zonas costeras.”
+                    <p class="text-white-p intro-home ">“¿Puedes escuchar el mar cuando acercas a tu oído una caracola marina? Te tenemos una invitación... a conocer el sonido de la costa, las voces de sus habitantes, sus preocupaciones y sus formas de cuidar el territorio y el mar. Dale play a nuestro podcast y sumérgete en estos testimonios sonoros sobre la vida y el futuro sostenible de las zonas costeras.”
                     </p>
                 </div>
             </div>
@@ -417,19 +416,19 @@
             <div class="row gx-4 gx-lg-5 justify-content-center">
                 <div class="col-lg-6 text-center">
                     <img src="assets/img/home/img-3.png">
-                    <p class="text-white-p light-text mb-4">"Desde el reconocimiento de ese lugar común que teníamos todos, este interés por el mar, empezamos a inciar las conversaciones"</p>
+                    <p class="text-white-p cuñas-home mb-4">"Desde el reconocimiento de ese lugar común que teníamos todos, este interés por el mar, empezamos a inciar las conversaciones"</p>
                     <p class="text-white-p nombre-personaje">Paulina Martínez</p>
                 </div>
             </div>
             <div class="row gx-4 gx-lg-5 justify-content-between">
                 <div class="col-md-6 text-center">
                     <img src="assets/img/home/img-1.png">
-                    <p class="text-white-p light-text mb-4">"Yo siempre me enojo con lo que es la construcción en la costa, en cualquier parte, en X lugar, con la gente que quiere tener más, teniendo algo, quieren llegar al mar, quieren romper el mar y quitarle lugar al mar"</p>
+                    <p class="text-white-p cuñas-home light-text mb-4">"Yo siempre me enojo con lo que es la construcción en la costa, en cualquier parte, en X lugar, con la gente que quiere tener más, teniendo algo, quieren llegar al mar, quieren romper el mar y quitarle lugar al mar"</p>
                     <p class="text-white-p nombre-personaje">Martín González</p>
                 </div>
                 <div class="col-md-6 text-center pb-5">
                     <img src="assets/img/home/img-2.png">
-                    <p class="text-white-p light-text mb-4">"Aquí yo pertenezco al movimiento salvemos el Río Cisnes que desde el año 2017 nosotros estamos luchando"</p>
+                    <p class="text-white-p cuñas-home mb-4">"Aquí yo pertenezco al movimiento salvemos el Río Cisnes que desde el año 2017 nosotros estamos luchando"</p>
                     <p class="text-white-p nombre-personaje">Yolanda Subiabre</p>
                 </div>
             </div>
@@ -482,8 +481,8 @@
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">
                 <div class="col-lg-8 text-center pt-5">
-                    <p class="text-white-p light-text">En nuestro <span class="regular-bold">Proyecto Caracola</span>, buscamos tus historias, anécdotas, problemáticas y desafíos en torno a la costa y su sostenibilidad.</p>
-                    <p class="text-white-p light-text">Tu relato podrá ser parte de este, el cual recoge las vivencias de diversas personas en las zonas costeras de nuestro país.</p>
+                    <p class="text-white-p intro-home">En nuestro <span class="regular-bold">Proyecto Caracola</span>, buscamos tus historias, anécdotas, problemáticas y desafíos en torno a la costa y su sostenibilidad.</p>
+                    <p class="text-white-p intro-home">Tu relato podrá ser parte de este, el cual recoge las vivencias de diversas personas en las zonas costeras de nuestro país.</p>
                    <br>
                    <br>
                    <div class="row gx-4 gx-lg-5 justify-content-center">
@@ -518,19 +517,19 @@
                 <div class="col-lg-4 col-md-6 text-center">
                     <div class="mt-5">
                         <div class="mb-4"><img src="./assets/img/icons/mouse_scroll.svg" width="120" class="img-fluid"></div>
-                        <h3 class="h4 mb-1 text-white light-text">RECORRE EL SITIO <br>HACIENDO SCROLL</h3>
+                        <h3 class="h4 mb-1 icon-text text-white ">RECORRE EL SITIO <br>HACIENDO SCROLL</h3>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 text-center">
                     <div class="mt-5">
                         <div class="mb-4"><img src="./assets/img/icons/mouse_select.svg" width="120" class="img-fluid"></div>
-                        <h3 class="h4 mb-1 text-white light-text">SELECCIONA <br>UNA ZONA</h3>
+                        <h3 class="h4 mb-1 icon-text text-white ">SELECCIONA <br>UNA ZONA</h3>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 text-center">
                     <div class="mt-5">
                         <div class="mb-4"><img src="./assets/img/icons/listen_to.svg" width="120" class="img-fluid"></div>
-                        <h3 class="h4 mb-1 text-white light-text">ESCUCHA LOS <br>TESTIMONIOS</h3>
+                        <h3 class="h4 mb-1 icon-text text-white ">ESCUCHA LOS <br>TESTIMONIOS</h3>
                     </div>
                 </div>
             </div>
@@ -1108,6 +1107,7 @@
         
           <div class="region col-xs-4 col-sm-4 col-md-6 col-ml-6 col-lg-6" id="region">
             <a href="index.html#region"></a>
+            
             <!-- Zona 1 -->
               <div class="zona1 fade-in-image">
                 <div class="chapter-container">
@@ -1228,7 +1228,7 @@
 
     <footer class="footer-bg">
         <div class="container px-4 px-lg-5">
-            <div class="small text-center text-white">Sitio desarrollado por FEF </div>
+            <div class="small text-center text-white">Sitio desarrollado por <a class="text-white"href="https://fef.cl/" target="_blank">FEF</a></div>
         </div>
     </footer>
 
@@ -1341,7 +1341,7 @@
 
 <script>
     $('a.active-text').click(function(){
-        $('a.submenu-text').removeClass("active");
+        $('a.active-text').removeClass("active");
         $(this).addClass("active");
     });
     </script>

--- a/js/mapa.js
+++ b/js/mapa.js
@@ -22,6 +22,7 @@ $(document).ready(function () {
 $('.valpo').click(function (e) {
     e.preventDefault(); $(".zona2").show();
     $(".zona1, .zona3, .zona4").hide();
+  //  window.alert("screen width" + screen.width)
     if(screen.width < 576){
         location.href = "index.html#region";
       }

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -127,12 +127,12 @@ window.addEventListener('DOMContentLoaded', event => {
 
 
 
-var header = document.getElementById("zonas");
-var btns = header.getElementsByClassName("btn");
-for (var i = 0; i < linked.length; i++) {
-    btns[i].addEventListener("click", function() {
-  var current = document.getElementsByClassName("active");
-  current[0].className = current[0].className.replace(" active", "");
-  this.className += " active";
-  });
-}
+// var header = document.getElementById("zonas");
+// var btns = header.getElementsByClassName("btn");
+// for (var i = 0; i < btns.length; i++) {
+//     btns[i].addEventListener("click", function() {
+//   var current = document.getElementsByClassName("active");
+//   current[0].className = current[0].className.replace(" active", "");
+//   this.className += " active";
+//   });
+// }

--- a/nuestro-proyecto.html
+++ b/nuestro-proyecto.html
@@ -92,32 +92,33 @@
 
           
 
-            <div class="container text-center">
+            <div class="container text-left align-content-center">
 
-                <div class="row mt-5">
-                    <div class="col">
+                <div class="row mt-5 justify-content-evenly align-content-center">
+
+                    <div class="zonas col-4">
                         <div class="caja c1">
-                            <h5 class="text-white regular-bold mt-5 mb-2 menu-cap" onclick="myFunction()">COQUIMBO </h5>
-                            <p class="text-white submenu-cap">CALETA CHUNGUNGO</p>
+                            <h5 class="text-white regular-bold mt-5 mb-3 menu-cap">ZONA 1: COQUIMBO </h5>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: C. CHUNGUNGO</a>
                         </div>
                         <div class="caja c4">
-                            <h5 class="text-white mt-5 regular-bold mb-2 menu-cap" onclick="myFunction()">VALPARAÍSO </h5>
-                            <p class="text-white submenu-cap">ZAPALLAR</p>
-                            <p class="text-white submenu-cap">ALGARROBO</p>
+                            <h5 class="text-white mt-5 regular-bold mb-3 menu-cap">ZONA 2: VALPARAÍSO </h5>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: ZAPALLAR</a>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: ALGARROBO</a>
                         </div>
                         <div class="caja c6">
-                            <h5 class="text-white mt-5 regular-bold mb-2 menu-cap" onclick="myFunction()">BÍO BÍO </h5>
-                            <p class="text-white submenu-cap">EL MAULE</p>
+                            <h5 class="text-white mt-5 regular-bold mb-3 menu-cap">ZONA 3: BÍO BÍO </h5>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: EL MAULE</a>
                         </div>
                         <div class="caja c8 ">
-                            <h5 class="text-white mt-5 regular-bold mb-2 menu-cap" onclick="myFunction()">LOS LAGOS </h5>
-                            <p class="text-white submenu-cap">HUALAIHUÉ</p>
+                            <h5 class="text-white mt-5 mb-3 menu-cap">ZONA 4: LOS LAGOS </h5>
+                            <a class="text-white active-text submenu-text" onclick="myFunction()">·SECTOR: HUALAIHUÉ</a>
                           
                         </div>
                     </div>
                    
 
-                    <div class="col">
+                    <div class="col-4">
 
 
                         <div id="c3" class="c3">
@@ -129,7 +130,7 @@
 
                         <!-- <div id="c4" class="c4"> -->
                              <a href="capitulo-1.html">     
-                                        <h5 class="text-white text-left mt-5 menu-cap">Refugios Marinos Zapallar</h5>
+                                <h5 class="text-white text-left mt-5 menu-cap regular-bold menu-link">REFUGIOS MARINOS</h5>
                          </div> 
 
 
@@ -410,7 +411,7 @@
 
     <footer class="footer-bg">
         <div class="container px-4 px-lg-5">
-            <div class="small text-center text-white">Sitio desarrollado por FEF </div>
+            <div class="small text-center text-white">Sitio desarrollado por <a class="text-white"href="https://fef.cl/" target="_blank">FEF</a></div>
         </div>
     </footer>
 


### PR DESCRIPTION
Cambios estilos textos home, Pidieron mas legibilidad-grosor.
links en footer a pag fef.
Estilos replicados sidebar de nuestro proyecto ( falta replicar sidebar y estilos en capitulo)
Le di al navbar text del menu principal mas letter space.

Pendientes:

sacar reporte de analitics del landing y mandar a secos
Mapa: ponerle descripciones de próximo episodio para dejarlo en los capítulos que no están listos
Que no quede tanto espacio entre las secciones de los capítulos
Escribir un texto de explicación antes del capítulo con la opción de escucharlo de uno o explorar con sus partes
Poner un texto que explique cada sección (estos textos nos lo tiene que mandar secos)
Ponerle una marca donde está zapallar
Indicar de mejor manera que el botón de menú es un menú
Cambiar el zona 2 zapallar a Sector zapallar
Hay que meter a upwell a la página, Fernandode SECOS va a resolver cómo
